### PR TITLE
更新 libzxing/build.gradle 固定 com.android.support:appcompat-v7 版本

### DIFF
--- a/libzxing/build.gradle
+++ b/libzxing/build.gradle
@@ -27,7 +27,7 @@ dependencies {
     androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    compile 'com.android.support:appcompat-v7:22.+'
+    compile 'com.android.support:appcompat-v7:22.2.1'
     testCompile 'junit:junit:4.12'
     compile 'com.google.zxing:core:3.3.0'
 }


### PR DESCRIPTION
固定 com.android.support:appcompat-v7:22.+ 依赖，使用 API 22 最后一个版本 22.2.1
以防 Gradle 每次 sync 都去请求网络解析版本